### PR TITLE
v1.0.4

### DIFF
--- a/asn.go
+++ b/asn.go
@@ -114,8 +114,11 @@ func (r ASN1Notation) Index(idx int) (nanf NameAndNumberForm, ok bool) {
 /*
 NewASN1Notation returns an instance of *[ASN1Notation] alongside an error.
 
-Valid input forms for ASN.1 values are string (e.g.: "{iso(1)}") and string
-slices (e.g.: []string{"iso(1)", "identified-organization(3)" ...}).
+Valid input forms for ASN.1 values are:
+
+  - string (e.g.: "{iso(1) ... }")
+  - string slices (e.g.: []string{"iso(1)", "identified-organization(3)" ...})
+  - [NameAndNumberForm] slices ([][NameAndNumberForm]{...})
 
 Note that the following root node abbreviations are supported:
 

--- a/oid_test.go
+++ b/oid_test.go
@@ -2,6 +2,7 @@ package objectid
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 )
 
@@ -146,6 +147,19 @@ func TestOID_bogus(t *testing.T) {
 
 	if _, err := NewOID(`joint-iso-itu-t thing`); err == nil {
 		t.Errorf("%s successfully parsed bogus value; expected an error", t.Name())
+		return
+	}
+
+	if _, err := NewOID([]NameAndNumberForm{
+		{identifier: `iso`, primaryIdentifier: NumberForm(*big.NewInt(1)), parsed: true},
+		{identifier: `identified-organization`, primaryIdentifier: NumberForm(*big.NewInt(3)), parsed: true},
+	}); err != nil {
+		t.Errorf("%s error: %v", t.Name(), err)
+		return
+	}
+
+	if _, err := NewOID([]NameAndNumberForm{}); err == nil {
+		t.Errorf("%s error: %v", t.Name(), err)
 		return
 	}
 }


### PR DESCRIPTION
## v1.0.4 Changes

 - Test and doc updates
 - Utilize `*big.Int`-based NumberForm, thereby allowing unbounded values in compliance with ASN.1
 -  Major ASN.1 codec update -- ASN.1 encoding/decoding now supported (**without use of encoding/asn1**)
 - 100% code coverage
 - root node abbreviations now supported for `ASN1Notation` input processing:
   - `itu-t` resolves to `itu-t(0)`
   - `iso` resolves to `iso(1)`
   - `joint-iso-itu-t` resolves to `joint-iso-itu-t(2)`
 - Compatible methods for quick output to `encoding/asn1.ObjectIdentifier` and `crypto/x509.OID` instances
 - New feature allowing mixed variadic input, such as `uint(1), "3", uint64(6)` for OID "1.3.6", to be used as input for `NewDotNotation`.  This allows the following type instances:
   - `*big.Int`
   - `string`
   - `uint64`
   - `uint`
   - `int`